### PR TITLE
Add caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/grafana/grafana-starter-datasource-backend
 
 go 1.16
 
-require github.com/grafana/grafana-plugin-sdk-go v0.102.0
+require (
+	github.com/dgraph-io/ristretto v0.1.0
+	github.com/grafana/grafana-plugin-sdk-go v0.102.0
+)

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,13 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
+github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -78,6 +83,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -250,6 +256,7 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/plugin/exchangerates.go
+++ b/pkg/plugin/exchangerates.go
@@ -25,6 +25,22 @@ func (r *Rates) Size() int64 {
 	return int64(((24 + 8) * len(r.Rates)) + (24 * len(r.Order)))
 }
 
+func (r *Rates) ContainsToday() bool {
+	// we completely depend on Rates containing UTC timezones here..
+	now := time.Now().UTC()
+
+	_, ok := r.Rates[now]
+	return ok
+}
+
+func calcTTL() time.Duration {
+	now := time.Now().UTC()
+	tomorrow := now.Add(time.Hour * 24)
+
+	midnight := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC)
+	return midnight.Sub(now)
+}
+
 func (d *ExchangeRatesDataSource) fetchRange(base string, from, to time.Time, symbol string) (*Rates, error) {
 	var out *Rates
 	var err error
@@ -73,7 +89,16 @@ func (d *ExchangeRatesDataSource) fetchRange(base string, from, to time.Time, sy
 
 	sort.SliceStable(out.Order, func(i, j int) bool { return out.Order[i].Unix() < out.Order[j].Unix() })
 
-	d.cache.SetWithTTL(key, out, out.Size(), calcTTL())
+	// if our rates set contains today then we will cache it till the end of the day UTC
+	// as that's when our source updates roughly.. if we however don't contain today
+	// we will cache for 5 minutes. this is mostly to not possibly send repeated requests upstream
+	ttl := time.Minute * 5
+	if out.ContainsToday() {
+		ttl = calcTTL()
+	}
+
+	log.DefaultLogger.Info(fmt.Sprintf("Caching %s (%d) for %s", key, out.Size(), ttl))
+	d.cache.SetWithTTL(key, out, out.Size(), ttl)
 
 	return out, nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
+	"github.com/dgraph-io/ristretto"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 // Make sure SampleDatasource implements required interfaces. This is important to do
@@ -26,8 +29,18 @@ var (
 
 // NewExchangeRatesDatasource creates a new datasource instance.
 func NewExchangeRatesDatasource(_ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1 * 1024 * 1024,  // 1MB
+		MaxCost:     32 * 1024 * 1024, // 32MB
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &ExchangeRatesDataSource{
 		httpClient: http.DefaultClient,
+		cache:      cache,
 	}, nil
 }
 
@@ -35,6 +48,7 @@ func NewExchangeRatesDatasource(_ backend.DataSourceInstanceSettings) (instancem
 // its health and has streaming skills.
 type ExchangeRatesDataSource struct {
 	httpClient *http.Client
+	cache      *ristretto.Cache
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
@@ -86,6 +100,15 @@ type queryModel struct {
 	ToCurrency   string `json:"toCurrency"`
 }
 
+func calcCost(in map[time.Time]float64) int64 {
+	// 24 is the size of a time.Time, 8 is the size of float64.. we just multiply it with the amount of items
+	return int64((24 + 8) * len(in))
+}
+
+func calcTTL() time.Duration {
+	return time.Hour
+}
+
 func (d *ExchangeRatesDataSource) query(_ context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
 	log.DefaultLogger.Info("query", "json", query.JSON)
 	response := backend.DataResponse{}
@@ -98,11 +121,23 @@ func (d *ExchangeRatesDataSource) query(_ context.Context, pCtx backend.PluginCo
 		return response
 	}
 
-	frame, err := d.fetchRange(qm.BaseCurrency, query.TimeRange.From, query.TimeRange.To, qm.ToCurrency)
+	rates, err := d.fetchRange(qm.BaseCurrency, query.TimeRange.From, query.TimeRange.To, qm.ToCurrency)
 	if err != nil {
 		response.Error = err
 		return response
 	}
+
+	frame := data.NewFrame("response")
+
+	frame.Fields = append(frame.Fields, data.NewField("time", nil, rates.Order))
+
+	exchangeRate := make([]float64, 0, len(rates.Order))
+
+	for _, when := range rates.Order {
+		exchangeRate = append(exchangeRate, rates.Rates[when])
+	}
+
+	frame.Fields = append(frame.Fields, data.NewField(qm.ToCurrency, nil, exchangeRate))
 
 	// add the frames to the response.
 	response.Frames = append(response.Frames, frame)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/dgraph-io/ristretto"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -98,15 +97,6 @@ func (d *ExchangeRatesDataSource) QueryData(ctx context.Context, req *backend.Qu
 type queryModel struct {
 	BaseCurrency string `json:"baseCurrency"`
 	ToCurrency   string `json:"toCurrency"`
-}
-
-func calcCost(in map[time.Time]float64) int64 {
-	// 24 is the size of a time.Time, 8 is the size of float64.. we just multiply it with the amount of items
-	return int64((24 + 8) * len(in))
-}
-
-func calcTTL() time.Duration {
-	return time.Hour
 }
 
 func (d *ExchangeRatesDataSource) query(_ context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {


### PR DESCRIPTION
We obviously don't want to make http requests for every query from grafana. Especially because the data only updates once a day. Ideally our cache is smart and will figure out whether the requested time range is in the cache or not. And if needed automatically extend it to include it.