### PR TITLE
Bugfix, explicitly check whether we actually have data before caching it

### DIFF
--- a/pkg/plugin/exchangerates.go
+++ b/pkg/plugin/exchangerates.go
@@ -88,8 +88,11 @@ func (d *ExchangeRatesDataSource) fetchRange(base string, from, to time.Time, sy
 			continue
 		}
 
-		out.Rates[when] = rate[symbol]
-		out.Order = append(out.Order, when)
+		v, ok := rate[symbol]
+		if ok {
+			out.Rates[when] = v
+			out.Order = append(out.Order, when)
+		}
 	}
 
 	sort.SliceStable(out.Order, func(i, j int) bool { return out.Order[i].Unix() < out.Order[j].Unix() })


### PR DESCRIPTION
This would especially happen around midnight UTC, where the api we use would already return a json object for the new day. But fill it without any data. And as it turns out, if your datatype is float64 and you retrieve it from a map. It will just be 0 if it's not there.. So we now explicitly check whether it's in the map before we cache it.

This would basically result in this. 
![2022-10-22_02-36](https://user-images.githubusercontent.com/417618/197308476-ab2c5e7b-ce09-4f85-b816-ba60d8b3d432.png)